### PR TITLE
Update the default image and add environment info

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a problem
+    url: https://jb.gg/qodana-issue
+    about: Report a bug to Qodana team.
+  - name: Share your feedback
+    url: https://jb.gg/qodana-discussions
+    about: Share your feedback with the Qodana team on our Discussions.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2.4.0
 
-      - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v3.2.1
+      - name: Qodana Scan
+        uses: JetBrains/qodana-action@v4.2.2
 
   test:
     name: Test

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
+# Gradle Qodana Plugin
+
 [![official JetBrains project](https://jb.gg/badges/official.svg)][jb:confluence-on-gh]
 [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/org.jetbrains.qodana?color=green&label=Gradle%20Plugin%20Portal&logo=gradle)][gradle-plugin-page]
 [![Build](https://github.com/JetBrains/gradle-grammar-kit-plugin/workflows/Build/badge.svg)][gh:build]
-[![Slack](https://img.shields.io/badge/Slack-%23qodana-blue)][jb:slack]
-[![Twitter Follow](https://img.shields.io/twitter/follow/QodanaEvolves?style=flat)][jb:twitter]
+[![GitHub Discussions](https://img.shields.io/github/discussions/jetbrains/qodana)][jb:discussions]
+[![Twitter Follow](https://img.shields.io/twitter/follow/QodanaEvolves?style=social&logo=twitter)][jb:twitter]
 
-# Gradle Qodana Plugin
-
-Gradle interface to run code inspections from Intellij IDEA.
+Gradle interface to run code inspections from IntelliJ IDEA.
 
 > **Important:**
 > This project requires Gradle 6.6 or newer, however it is recommended to use the [latest Gradle available](https://gradle.org/releases/). Update it with:
@@ -22,7 +22,7 @@ If you'd like to file a new issue, please use the following [YouTrack | New Issu
 
 ## Docker Image with Qodana tool
 
-Docker Hub: https://hub.docker.com/r/jetbrains/qodana
+Docker Hub: https://hub.docker.com/r/jetbrains/qodana-jvm-community
 
 ## Gradle Qodana Configuration
 
@@ -58,7 +58,7 @@ Properties available for configuration in the `qodana { }` top level configurati
 | `baselineIncludeAbsent` | Include in the output report the results from the baseline run that are absent in the current run.                                | `Boolean` | `false`                                 |
 | `cachePath`             | Path to the cache directory.                                                                                                      | `String`  | `null`                                  |
 | `dockerContainerName`   | Name of the Qodana Docker container.                                                                                              | `String`  | `idea-inspections`                      |
-| `dockerImageName`       | Name of the Qodana Docker image.                                                                                                  | `String`  | `jetbrains/qodana:latest`               |
+| `dockerImageName`       | Name of the Qodana Docker image.                                                                                                  | `String`  | `jetbrains/qodana-jvm-community:latest` |
 | `executable`            | Docker executable name.                                                                                                           | `String`  | `docker`                                |
 | `projectPath`           | Path to the project folder to inspect.                                                                                            | `String`  | `project.projectDir`                    |
 | `failThreshold`         | A number of problems that will serve as a quality gate. If this number is reached, the inspection run is terminated.              | `Int`     | `10000`                                 |
@@ -164,14 +164,14 @@ gradle runInspections
 ./gradlew runInspections
 ```
 
-Full guide for options and configuration parameters could be found on [qodana docs page](https://www.jetbrains.com/help/qodana/qodana-intellij-docker-readme.html#Using+an+existing+profile). 
+Full guide for options and configuration parameters could be found on [qodana docs page](https://www.jetbrains.com/help/qodana/qodana-jvm-docker-techs.html). 
 
 ## Build Locally
 
 ### Build 
 
 Execute Gradle task `publishToMavenLocal` to build Gradle Qodana Plugin and publish it into local Maven repository.
-By default, plugin will be published into `~/.mvn/org/jetbrins/qodana/` directory.
+By default, plugin will be published into `~/.mvn/org/jetbrains/qodana/` directory.
 
 ### Apply
 
@@ -217,7 +217,7 @@ Apply Gradle Qodana Plugin with snapshot version in Gradle configuration file an
 [gh:build]: https://github.com/JetBrains/gradle-qodana-plugin/actions?query=workflow%3ABuild
 [gradle-plugin-page]: https://plugins.gradle.org/plugin/org.jetbrains.qodana
 [jb:confluence-on-gh]: https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub
-[jb:slack]: https://qodana.slack.com
+[jb:discussions]: https://jb.gg/qodana-discussions
 [jb:twitter]: https://twitter.com/QodanaEvolves
 [youtrack]: https://youtrack.jetbrains.com/issues/QD
 [youtrack-new-issue]: https://youtrack.jetbrains.com/newIssue?project=QD&c=Platform%20Gradle%20Plugin&c=Tool%20IntelliJ%20(Code%20Inspection)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ fun properties(key: String) = project.findProperty(key)?.toString()
 plugins {
     `kotlin-dsl`
     `maven-publish`
-    kotlin("jvm") version "1.6.0"
-    id("com.gradle.plugin-publish") version "0.18.0"
+    kotlin("jvm") version "1.6.10"
+    id("com.gradle.plugin-publish") version "0.19.0"
 }
 
 group = "org.jetbrains.qodana"

--- a/src/main/kotlin/org/jetbrains/qodana/QodanaPluginConstants.kt
+++ b/src/main/kotlin/org/jetbrains/qodana/QodanaPluginConstants.kt
@@ -11,7 +11,8 @@ object QodanaPluginConstants {
     const val UPDATE_INSPECTIONS_TASK_NAME = "updateInspections"
     const val CLEAN_INSPECTIONS_TASK_NAME = "cleanInspections"
 
+    const val QODANA_ENV_NAME = "gradle"
     const val DOCKER_CONTAINER_NAME_INSPECTIONS = "idea-inspections"
-    const val DOCKER_IMAGE_NAME_INSPECTIONS = "jetbrains/qodana:latest"
+    const val DOCKER_IMAGE_NAME_INSPECTIONS = "jetbrains/qodana-jvm-community:latest"
 }
 

--- a/src/main/kotlin/org/jetbrains/qodana/tasks/RunInspectionsTask.kt
+++ b/src/main/kotlin/org/jetbrains/qodana/tasks/RunInspectionsTask.kt
@@ -3,14 +3,9 @@ package org.jetbrains.qodana.tasks
 import org.apache.tools.ant.util.TeeOutputStream
 import org.gradle.api.GradleException
 import org.gradle.api.provider.ListProperty
-import org.gradle.api.tasks.Exec
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.property
+import org.jetbrains.qodana.QodanaPluginConstants
 import java.io.ByteArrayOutputStream
 import java.io.File
 
@@ -233,6 +228,7 @@ open class RunInspectionsTask : Exec() {
         val args = mutableListOf(
             "run",
             "--rm",
+            "-e QODANA_ENV=${QodanaPluginConstants.QODANA_ENV_NAME}",
             "--name", dockerContainerName.get(),
         )
 

--- a/src/test/kotlin/org/jetbrains/qodana/tasks/RunInspectionsTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/qodana/tasks/RunInspectionsTaskTest.kt
@@ -20,7 +20,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -44,7 +44,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name FOO " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -75,7 +75,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $projectPath:/data/project " +
@@ -102,7 +102,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p 12345:8080 " +
                 "-v $root:/data/project " +
@@ -158,7 +158,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -182,7 +182,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -206,7 +206,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -230,7 +230,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-p 123:456 " +
@@ -256,7 +256,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -280,7 +280,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -304,7 +304,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -328,7 +328,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -355,7 +355,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +
@@ -380,7 +380,7 @@ class RunInspectionsTaskTest : BaseTest() {
 
         assertEquals(
             "run " +
-                "--rm " +
+                "--rm -e QODANA_ENV=gradle " +
                 "--name $DOCKER_CONTAINER_NAME_INSPECTIONS " +
                 "-p $SHOW_REPORT_PORT:8080 " +
                 "-v $root:/data/project " +


### PR DESCRIPTION
We want to pass the environment information to Qodana Docker Image to check the plugin usages.
Also, this MR changes the default image to jetbrains/qodana-jvm-community and bumps some dependencies. 

And a few fixes to README, given that we switched from Slack to GitHub Discussions and other things 🙃